### PR TITLE
Fix a warning under Python 3.7+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,13 @@ setup(
         },
     url='https://github.com/feeluown/feeluown-download',
     keywords=['feeluown', 'plugin', 'download'],
-    classifiers=(
+    classifiers=[
         'Development Status :: 3 - Alpha',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3 :: Only',
-        ),
+    ],
     install_requires=['feeluown>=3.5.3', 'requests'],
     entry_points={
         'fuo.plugins_v1': [


### PR DESCRIPTION
`Warning: 'classifiers' should be a list, got type 'tuple'`

Related issue: https://bugs.python.org/issue19610