### PR TITLE
fix compatibility with feeluown >= 3.7.4 (#4)

### DIFF
--- a/fuo_dl/ui.py
+++ b/fuo_dl/ui.py
@@ -77,10 +77,8 @@ class DownloadUi:
             self._app.library.song_prepare_media,
             song,
             self._app.playlist.audio_select_policy)
-        if hasattr(media, 'url'):
-            media_url = media.url
-        else:
-            media_url = media
+        media = Media(media)
+        media_url = media.url
         if media_url:
             ext = guess_media_url_ext(media_url)
             filename = cook_filename(title, artists_name, ext)


### PR DESCRIPTION
In feeluown/FeelUOwn#459, `self._app.playlist.prepare_media` got refactored. This plugin needs to be updated.

In feeluown/FeelUOwn@b5fa850, `feeluown.helpers` is moved to `feeluown.gui.helpers`

Some plugins use `media` for the URL and some use `media.url`. This tries to use either of them.